### PR TITLE
cmake: derive --version from the CMake project version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(clx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(clx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 target_compile_definitions(clx PRIVATE
+    CLX_VERSION="${PROJECT_VERSION}"
     CLX_DEFAULT_CXX="${CMAKE_CXX_COMPILER}"
     CLX_DEFAULT_CXX_NAME="${CMAKE_CXX_COMPILER_ID}"
 )

--- a/src/clx.cpp
+++ b/src/clx.cpp
@@ -29,6 +29,10 @@
 
 namespace fs = std::filesystem;
 
+#ifndef CLX_VERSION
+    #error "CLX_VERSION not defined — rebuild with CMake"
+#endif
+
 std::vector<std::string> precompiled_modules;
 
 //------------------ ENUM: BuildMode - output mode (executable binary, object file, or static library)
@@ -162,7 +166,7 @@ int main(int argc, char* argv[]) {
             print_help();
             return 0;
         } else if (arg == "--version") {
-            std::cout << "clx 0.1.0\nMIT License - Copyright (c) 2026 Tine Samir\n";
+            std::cout << "clx " CLX_VERSION "\nMIT License - Copyright (c) 2026 Tine Samir\n";
             return 0;
         } else if (arg == "--output" || arg == "-o") {
             if (i + 1 < argc) custom_output_name = argv[++i];


### PR DESCRIPTION
The --version output was hardcoded to "clx 0.1.0" in src/clx.cpp while CMakeLists.txt declared project VERSION 0.2.0, so an installed clx reported a stale version. Pass PROJECT_VERSION in as the CLX_VERSION compile definition and print that, matching the existing CLX_DEFAULT_CXX pattern, so the two can no longer drift.

Note: there are a couple other instances of 0.1.0 in the index.html but I left them alone 👀