### PR TITLE
Intern error messages thrown without an LState

### DIFF
--- a/include/clx_runtime.h
+++ b/include/clx_runtime.h
@@ -1548,10 +1548,13 @@ public:
     virtual const char* what() const noexcept override;
 };
 
+//------------------ Interns an error message raised without an LState
+const char* intern_error_message(const char* msg, size_t len);
+
 //------------------ Throws an LRuntimeException
 [[noreturn]] CLX_INLINE_COLD void throw_runtime_error(const char* msg)
 {
-    throw LRuntimeException(LValue(msg));
+    throw LRuntimeException(LValue(intern_error_message(msg, clx_strlen(msg))));
 }
 
 //------------------ Stack scope guard

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -304,6 +305,16 @@ MultiValue close_thread(LState* L, const LValue& thread)
         return MultiValue(clx::boolean(true));
 
     return MultiValue(clx::boolean(false));
+}
+
+//------------------ intern_error_message — interns an error message raised without an LState
+const char* intern_error_message(const char* msg, size_t len)
+{
+    static std::mutex pool_mutex;
+    static StringPool pool;
+    uint64_t h = len <= 8 ? swar_hash_8(msg, len) : wyhash_str(msg, len);
+    std::lock_guard<std::mutex> guard(pool_mutex);
+    return pool.intern(msg, len, h);
 }
 
 //------------------ LRuntimeException::LRuntimeException — error exception constructor


### PR DESCRIPTION
`throw_runtime_error()` never interned its message, so the error value has no length header and dangles when the caller passed a local buffer.