### PR TITLE
Intern string literals used as error values

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -80,7 +80,7 @@ static void fiber_entry_impl(LThread* t)
             t->status = THREAD_DEAD;
             t->has_error = true;
         } catch (...) {
-            t->yield_args = MultiValue(clx::LValue("unknown error"));
+            t->yield_args = MultiValue(clx::LValue(L->intern_string("unknown error")));
             t->status = THREAD_DEAD;
             t->has_error = true;
         }

--- a/src/runtime/vm/vm_function_object.cpp
+++ b/src/runtime/vm/vm_function_object.cpp
@@ -68,7 +68,7 @@ MultiValue VMFunction::invoke(LState* clx_L, const LValue* args, size_t nargs)
     MultiValue out;
     if (!vm_pcall_function_(clx_L, registry_ref, args, nargs, out)) {
 
-        LValue err = (out.count > 0) ? out[0] : LValue("VM error");
+        LValue err = (out.count > 0) ? out[0] : LValue(clx_L->intern_string("VM error"));
         throw LRuntimeException(err);
     }
     return out;


### PR DESCRIPTION
`LValue("unknown error")` and `LValue("VM error")` are built straight from literals, so they have no length header.