### PR TITLE
Keep embedded NULs when converting string values to std::string

### DIFF
--- a/src/runtime/base.cpp
+++ b/src/runtime/base.cpp
@@ -255,8 +255,10 @@ static MultiValue tostring(LState* L, const LValue* args, size_t count)
         int n = std::snprintf(buf, sizeof(buf), "%lld", (long long)v.as_integer());
         return MultiValue(clx::string(L, buf, (size_t)n));
     }
-    default:
-        return MultiValue(clx::string(L, v.to_string(L).c_str()));
+    default: {
+        std::string sv = v.to_string(L);
+        return MultiValue(clx::string(L, sv.data(), sv.size()));
+    }
     }
 }
 

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -354,7 +354,7 @@ std::string LValue::to_string(LState* L) const
                 L->shadow_top--;
 
                 if (ret.count > 0 && ret[0].type == String) {
-                    return std::string(ret[0].as_string());
+                    return std::string(ret[0].as_string(), ret[0].string_len());
                 }
             }
         }
@@ -373,7 +373,7 @@ std::string LValue::to_string(LState* L) const
     case Int64:
         return std::to_string(as_integer());
     case String:
-        return std::string(as_string());
+        return std::string(as_string(), string_len());
     case Table: {
         const char* prefix = "table";
         if (L) {


### PR DESCRIPTION
`LValue::to_string()` built its result with `std::string(as_string())`, which stops at the first `\0`, so any string with an embedded NUL got truncated. Same for the value returned by `__tostring`, and for the `tostring` builtin that re-interned it from a `const char*`.